### PR TITLE
Added custom package denylist MVP

### DIFF
--- a/client/src/main/java/net/kzxiv/notify/client/AppConstants.java
+++ b/client/src/main/java/net/kzxiv/notify/client/AppConstants.java
@@ -1,0 +1,7 @@
+package net.kzxiv.notify.client;
+
+public class AppConstants {
+    public static final String TAG = "notifikator";
+    public static final String PACKAGE_DENY_LIST_PREF_KEY = "package_deny_list";
+
+}

--- a/client/src/main/java/net/kzxiv/notify/client/ConfigurationActivity.java
+++ b/client/src/main/java/net/kzxiv/notify/client/ConfigurationActivity.java
@@ -1,22 +1,107 @@
 package net.kzxiv.notify.client;
 
-import android.app.*;
-import android.content.res.*;
-import android.graphics.*;
-import android.graphics.drawable.*;
-import android.os.*;
-import android.preference.*;
+import android.app.Notification;
+import android.app.NotificationChannel;
+import android.app.NotificationManager;
+import android.app.Service;
+import android.content.Intent;
+import android.content.SharedPreferences;
+import android.content.res.Resources;
+import android.graphics.Bitmap;
+import android.graphics.Color;
+import android.graphics.drawable.BitmapDrawable;
+import android.net.Uri;
+import android.os.Bundle;
+import android.preference.Preference;
+import android.preference.PreferenceActivity;
+import android.preference.PreferenceManager;
+import android.preference.PreferenceScreen;
+import android.widget.Toast;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.util.HashSet;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 public class ConfigurationActivity extends PreferenceActivity
 {
+    private static final int PICK_FILE_REQUEST_CODE = 123;
+    private static final Pattern PACKAGE_NAME_REGEX = Pattern.compile("^[a-z]+(\\.[a-z0-9_]+)*$");
+
     protected void onCreate(Bundle savedInstanceState)
     {
         super.onCreate(savedInstanceState);
 
         PreferenceManager.setDefaultValues(this, R.xml.preferences, false);
         addPreferencesFromResource(R.xml.preferences);
+
+
+        Preference chooseFileButton = findPreference(getString(R.string.key_choose_denylist));
+        chooseFileButton.setOnPreferenceClickListener(new Preference.OnPreferenceClickListener() {
+            @Override
+            public boolean onPreferenceClick(Preference preference) {
+                openFilePickerForDenylist();
+                return true;
+            }
+        });
+
     }
 
+    private void openFilePickerForDenylist() {
+        Intent intent = new Intent(Intent.ACTION_OPEN_DOCUMENT);
+        intent.addCategory(Intent.CATEGORY_OPENABLE);
+        intent.setType("text/plain");
+        startActivityForResult(intent, PICK_FILE_REQUEST_CODE);
+    }
+
+    @Override
+    protected void onActivityResult(int requestCode, int resultCode, Intent data) {
+        super.onActivityResult(requestCode, resultCode, data);
+        if (requestCode == PICK_FILE_REQUEST_CODE && resultCode == RESULT_OK) {
+            if (data != null && data.getData() != null) {
+                Uri selectedFileUri = data.getData();
+                readDenylistFile(selectedFileUri);
+            }
+        }
+    }
+
+    private void readDenylistFile(Uri fileUri) {
+        try {
+            InputStream inputStream = getContentResolver().openInputStream(fileUri);
+            BufferedReader reader = new BufferedReader(new InputStreamReader(inputStream));
+            HashSet<String> lines = new HashSet<String>();
+            String line;
+
+            while ((line = reader.readLine()) != null) {
+                Matcher matcher = PACKAGE_NAME_REGEX.matcher(line);
+                if (matcher.matches()) {
+                    lines.add(line);
+                }
+                else {
+                    // TODO parsing error - should we ignore this package name, or stop parsing and err out?
+                    // For now we'll just ignore specific entries
+
+                    // TODO should source error text from res/values
+                    Toast.makeText(getApplicationContext(), String.format("Invalid package name for deny list - \"%s\"", line), Toast.LENGTH_SHORT).show();
+                }
+            }
+            reader.close();
+            inputStream.close();
+
+            // save result in stored preferences
+            SharedPreferences sharedPreferences = PreferenceManager.getDefaultSharedPreferences(getApplicationContext());
+            SharedPreferences.Editor editor = sharedPreferences.edit();
+
+            editor.putStringSet(AppConstants.PACKAGE_DENY_LIST_PREF_KEY, lines);
+            editor.apply();
+
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
     public boolean onPreferenceTreeClick(PreferenceScreen preferenceScreen, Preference preference)
     {
         int NOTIFICATION_ID = 0;

--- a/client/src/main/res/values/strings.xml
+++ b/client/src/main/res/values/strings.xml
@@ -10,6 +10,7 @@
     <string name="key_endpointuser">EndpointUsername</string>
     <string name="key_endpointpw">EndpointPassword</string>
     <string name="key_send">NotificationSend</string>
+    <string name="key_choose_denylist">ChooseDenylist</string>
 
     <string name="protocol_kodi">kodi</string>
     <string name="protocol_kodi_addon">kodi+addon</string>
@@ -38,6 +39,8 @@
     <string name="enabled_summary">Forward received notifications</string>
     <string name="wifionly">Wi-Fi Only</string>
     <string name="wifionly_summary">Only forward notifications when connected to Wi-Fi</string>
+    <string name="choose_denylist">Package Denylist File</string>
+    <string name="choose_denylist_summary">Select file to initialize package denylist</string>
     <string name="protocol">Protocol</string>
     <string name="protocol_summary">How to encode the notification data</string>
     <string name="notification_access">Open Notification Access</string>

--- a/client/src/main/res/xml/preferences.xml
+++ b/client/src/main/res/xml/preferences.xml
@@ -12,6 +12,11 @@
             android:key="@string/key_wifionly"
             android:defaultValue="false" />
         <Preference
+            android:title="@string/choose_denylist"
+            android:summary="@string/choose_denylist_summary"
+            android:key="@string/key_choose_denylist"
+            android:id="@+id/chooseDenylistButton" />
+        <Preference
             android:title="@string/notification_access"
             android:summary="@string/notification_access_summary">
             <intent android:action="android.settings.ACTION_NOTIFICATION_LISTENER_SETTINGS" />


### PR DESCRIPTION
This method currently allows the user to select a "denylist file" (which is defined as a plaintext file containing one package name per line), which will be parsed/stored in shared preferences.

Closes #1