### PR TITLE
Allow plain HTTP, ask user for POST_NOTIFICATIONS permission

### DIFF
--- a/client/src/main/AndroidManifest.xml
+++ b/client/src/main/AndroidManifest.xml
@@ -8,7 +8,8 @@
         android:allowBackup="true"
         android:label="@string/app_name"
         android:icon="@drawable/icon"
-        android:theme="@style/AppTheme">
+        android:theme="@style/AppTheme"
+        android:usesCleartextTraffic="true">
         <service
             android:name=".NotificationService"
             android:permission="android.permission.BIND_NOTIFICATION_LISTENER_SERVICE"

--- a/client/src/main/java/net/kzxiv/notify/client/ConfigurationActivity.java
+++ b/client/src/main/java/net/kzxiv/notify/client/ConfigurationActivity.java
@@ -1,9 +1,12 @@
 package net.kzxiv.notify.client;
 
+
+import android.Manifest;
 import android.app.Notification;
 import android.app.NotificationChannel;
 import android.app.NotificationManager;
 import android.app.Service;
+import android.content.pm.PackageManager;
 import android.content.Intent;
 import android.content.SharedPreferences;
 import android.content.res.Resources;
@@ -11,6 +14,7 @@ import android.graphics.Bitmap;
 import android.graphics.Color;
 import android.graphics.drawable.BitmapDrawable;
 import android.net.Uri;
+import android.os.Build;
 import android.os.Bundle;
 import android.preference.Preference;
 import android.preference.PreferenceActivity;
@@ -38,6 +42,11 @@ public class ConfigurationActivity extends PreferenceActivity
         PreferenceManager.setDefaultValues(this, R.xml.preferences, false);
         addPreferencesFromResource(R.xml.preferences);
 
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            if (checkSelfPermission(Manifest.permission.POST_NOTIFICATIONS) != PackageManager.PERMISSION_GRANTED) {
+                requestPermissions(new String[]{Manifest.permission.POST_NOTIFICATIONS}, 1);
+            }
+        }
 
         Preference chooseFileButton = findPreference(getString(R.string.key_choose_denylist));
         chooseFileButton.setOnPreferenceClickListener(new Preference.OnPreferenceClickListener() {


### PR DESCRIPTION
- Allow sending plaintext HTTP requests to http:// urls.
Use case: I have a tailscale (vpn) network connecting all of my devices and I use this app to send notifications from my phone to my home server as all traffic is already encrypted by wireguard.
- Prompt user to allow POST_NOTIFICATIONS permissions on startup in order for "Send a test notification" feature to work. Otherwise it is not intuitive that the user should grant the permission explicitly and the button will just silently fail.